### PR TITLE
German noun at its best

### DIFF
--- a/docs/csharp/language-reference/language-specification/index.md
+++ b/docs/csharp/language-reference/language-specification/index.md
@@ -1,5 +1,5 @@
 ---
-title: C# 6.0 Entwurf der Sprachspezifikation
+title: C# 6.0 Entwurfssprachenspezifikation
 ms.date: 07/01/2017
 ms.prod: .net
 ms.technology: devlang-csharp
@@ -19,14 +19,14 @@ ms.translationtype: HT
 ms.contentlocale: de-DE
 ms.lasthandoff: 10/18/2017
 ---
-# <a name="c-60-draft-language-specification"></a>C# 6.0 Entwurf der Sprachspezifikation
+# <a name="c-60-draft-language-specification"></a>Entwurf der C# 6.0-Sprachspezifikation
 Die C#-Sprachspezifikation ist die verbindliche Quelle für die Grammatik und Syntax von C#. Diese Spezifikation enthält ausführliche Informationen zu allen Aspekten der Programmiersprache, darunter auch viele Punkte, die in der Dokumentation zu Visual C# nicht behandelt werden.
 
 Sie können Version 5.0 dieser Spezifikation aus dem [Microsoft Download Center](http://www.microsoft.com/download/details.aspx?id=7029) herunterladen. Wenn Sie Visual Studio 2015 installiert haben, können Sie die Spezifikation auch auf Ihrem Computer im Ordner "Programme (x86)/Microsoft Visual Studio 14.0/VC#/Specifications/1033" finden. Wenn Sie eine andere Version von Visual Studio installiert haben oder wenn Ihre Version von Visual Studio nicht in Englisch ist, passen Sie den Pfad entsprechend an.
 
 Die Version 6.0 der Spezifikation wurde nicht als Standard genehmigt. Diese Website enthält einen [*Entwurf* der C# 6.0-Spezifikation](../../../../_csharplang/spec/lexical-structure.md). Diese wird aus den Markdowndateien erstellt, die in [dotnet/csharplang GitHub repository](https://github.com/dotnet/csharplang/blob/master/spec/README.md) enthalten sind.
 
-Probleme mit dem Entwurf der Spezifikation sollten im Repository [dotnet/csharplang](https://github.com/dotnet/csharplang/issues) erstellt werden. Falls Sie daran interessiert sind, die Fehler zu beheben, die Sie finden, können Sie einen [Pull Request](https://github.com/dotnet/csharplang/pulls) im selben Repository übermitteln.
+Probleme im Spezifikationsentwurf sollten im Repository [dotnet/csharplang](https://github.com/dotnet/csharplang/issues) gemeldet werden. Falls Sie gefundene Fehler beheben möchten, können Sie im selben Repository einen [Pull Request](https://github.com/dotnet/csharplang/pulls) erstellen.
 
 ## <a name="see-also"></a>Siehe auch  
  [C#-Referenz](../../language-reference/index.md)  

--- a/docs/csharp/language-reference/language-specification/index.md
+++ b/docs/csharp/language-reference/language-specification/index.md
@@ -1,5 +1,5 @@
 ---
-title: C# 6.0 Entwurfssprachenspezifikation
+title: C# 6.0 Entwurf der Sprachspezifikation
 ms.date: 07/01/2017
 ms.prod: .net
 ms.technology: devlang-csharp
@@ -26,7 +26,7 @@ Sie können Version 5.0 dieser Spezifikation aus dem [Microsoft Download Center]
 
 Die Version 6.0 der Spezifikation wurde nicht als Standard genehmigt. Diese Website enthält einen [*Entwurf* der C# 6.0-Spezifikation](../../../../_csharplang/spec/lexical-structure.md). Diese wird aus den Markdowndateien erstellt, die in [dotnet/csharplang GitHub repository](https://github.com/dotnet/csharplang/blob/master/spec/README.md) enthalten sind.
 
-Themen der Entwurfsspezifikation sollten im Repository [dotnet/csharplang](https://github.com/dotnet/csharplang/issues) erstellt werden. Falls Sie daran interessiert sind, die Fehler zu beheben, die Sie finden, können Sie einen [Pull Request](https://github.com/dotnet/csharplang/pulls) im selben Repository übermitteln.
+Probleme mit dem Entwurf der Spezifikation sollten im Repository [dotnet/csharplang](https://github.com/dotnet/csharplang/issues) erstellt werden. Falls Sie daran interessiert sind, die Fehler zu beheben, die Sie finden, können Sie einen [Pull Request](https://github.com/dotnet/csharplang/pulls) im selben Repository übermitteln.
 
 ## <a name="see-also"></a>Siehe auch  
  [C#-Referenz](../../language-reference/index.md)  

--- a/docs/csharp/language-reference/language-specification/index.md
+++ b/docs/csharp/language-reference/language-specification/index.md
@@ -19,7 +19,7 @@ ms.translationtype: HT
 ms.contentlocale: de-DE
 ms.lasthandoff: 10/18/2017
 ---
-# <a name="c-60-draft-language-specification"></a>C# 6.0 Entwurfssprachenspezifikation
+# <a name="c-60-draft-language-specification"></a>C# 6.0 Entwurf der Sprachspezifikation
 Die C#-Sprachspezifikation ist die verbindliche Quelle für die Grammatik und Syntax von C#. Diese Spezifikation enthält ausführliche Informationen zu allen Aspekten der Programmiersprache, darunter auch viele Punkte, die in der Dokumentation zu Visual C# nicht behandelt werden.
 
 Sie können Version 5.0 dieser Spezifikation aus dem [Microsoft Download Center](http://www.microsoft.com/download/details.aspx?id=7029) herunterladen. Wenn Sie Visual Studio 2015 installiert haben, können Sie die Spezifikation auch auf Ihrem Computer im Ordner "Programme (x86)/Microsoft Visual Studio 14.0/VC#/Specifications/1033" finden. Wenn Sie eine andere Version von Visual Studio installiert haben oder wenn Ihre Version von Visual Studio nicht in Englisch ist, passen Sie den Pfad entsprechend an.


### PR DESCRIPTION
The correct translation according to the content of this chapter would be `Sprachspezifikationsentwurf` and for a better readabillity I converted this to `Entwurf der Sprachspezifikation`. 

The second change is in the `Issues` sentence, where I would like to see `Probleme mit dem Entwurf der Spezifikation` because an `Issue` is more a problem than a topic.