### PR TITLE
Update net-standard-table.md

### DIFF
--- a/includes/net-standard-table.md
+++ b/includes/net-standard-table.md
@@ -1,16 +1,16 @@
-| .NET-Standard                             | [1.0] | [1.1]  | [1.2] | [1.3] | [1.4] | [1.5]  | [1.6]  | [2.0] |
-|-------------------------------------------|-------|--------|-------|-------|-------|--------|--------|-------|
-| .NET Core                                 | 1.0   | 1.0    | 1.0   | 1.0   | 1.0   | 1.0    | 1.0    | 2.0   |
-| .NET Framework (mit dem .NET Core 1.x SDK)   | 4.5   | 4.5    | 4.5.1 | 4.6   | 4.6.1 | 4.6.2  |        |       |
-| .NET Framework (mit dem .NET Core 2.0 SDK)   | 4.5   | 4.5    | 4.5.1 | 4.6   | 4.6.1 | 4.6.1  | 4.6.1  | 4.6.1 |
-| Mono                                      | 4.6   | 4.6    | 4.6   | 4.6   | 4.6   | 4.6    | 4.6    | 5.4   |
-| Xamarin.iOS                               | 10.0  | 10.0   | 10.0  | 10.0  | 10.0  | 10.0   | 10.0   | 10.14 |
-| Xamarin.Mac                               | 3.0   | 3.0    | 3.0   | 3.0   | 3.0   | 3.0    | 3.0    | 3.8   |
-| Xamarin.Android                           | 7.0   | 7.0    | 7.0   | 7.0   | 7.0   | 7.0    | 7.0    | 8.0   |
-| Universelle Windows-Plattform                | 10.0  | 10.0   | 10.0  | 10.0  | 10.0  | vNext  | vNext  | vNext |
-| Windows                                   | 8.0   | 8.0    | 8.1   |       |       |        |        |       |
-| Windows Phone                             | 8.1   | 8.1    | 8.1   |       |       |        |        |       |
-| Windows Phone Silverlight                 | 8.0   |        |       |       |       |        |        |       |
+| .NET-Standard                             | [1.0] | [1.1]  | [1.2] | [1.3] | [1.4] | [1.5]      | [1.6]      | [2.0]      |
+|-------------------------------------------|-------|--------|-------|-------|-------|------------|------------|------------|
+| .NET Core                                 | 1.0   | 1.0    | 1.0   | 1.0   | 1.0   | 1.0        | 1.0        | 2.0        |
+| .NET Framework (mit dem .NET Core 1.x SDK)| 4.5   | 4.5    | 4.5.1 | 4.6   | 4.6.1 | 4.6.2      |            |            |
+| .NET Framework (mit dem .NET Core 2.0 SDK)| 4.5   | 4.5    | 4.5.1 | 4.6   | 4.6.1 | 4.6.1      | 4.6.1      | 4.6.1      |
+| Mono                                      | 4.6   | 4.6    | 4.6   | 4.6   | 4.6   | 4.6        | 4.6        | 5.4        |
+| Xamarin.iOS                               | 10.0  | 10.0   | 10.0  | 10.0  | 10.0  | 10.0       | 10.0       | 10.14      |
+| Xamarin.Mac                               | 3.0   | 3.0    | 3.0   | 3.0   | 3.0   | 3.0        | 3.0        | 3.8        |
+| Xamarin.Android                           | 7.0   | 7.0    | 7.0   | 7.0   | 7.0   | 7.0        | 7.0        | 8.0        |
+| Universelle Windows-Plattform             | 10.0  | 10.0   | 10.0  | 10.0  | 10.0  | 10.0.16299 | 10.0.16299 | 10.0.16299 |
+| Windows                                   | 8.0   | 8.0    | 8.1   |       |       |            |            |            |
+| Windows Phone                             | 8.1   | 8.1    | 8.1   |       |       |            |            |            |
+| Windows Phone Silverlight                 | 8.0   |        |       |       |       |            |            |            |
 
 - Die Spalten stellen die .NET Standard-Versionen dar. Jede Zelle enthält einen Link zu einem Dokument, im dem die APIs angegeben sind, die in dieser Version von .NET Standard hinzugefügt wurden.
 - Die Zeilen stellen die verschiedenen .NET-Implementierungen dar.


### PR DESCRIPTION
Added UWP implementation support for .NET Standard 1.5, 1.6 and 2.0 according to the English docs found at [https://github.com/dotnet/docs/blob/live/includes/net-standard-table.md](https://github.com/dotnet/docs/blob/live/includes/net-standard-table.md)