### PR TITLE
propper naming of "build" tab

### DIFF
--- a/docs/csharp/language-reference/compiler-options/define-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/define-compiler-option.md
@@ -57,9 +57,9 @@ Die Option **-define** definiert `name` als Symbol in allen Quellcodedateien Ihr
   
 ### <a name="to-set-this-compiler-option-in-the-visual-studio-development-environment"></a>So legen Sie diese Compileroption in der Visual Studio-Entwicklungsumgebung fest  
   
-1.  Öffnen Sie die **Eigenschaftenseite** des Projekts.  
+1.  Öffnen Sie die **Eigenschaftenseiten** des Projekts.  
   
-2.  Geben Sie auf der Registerkarte **Erstellen** im Feld **Symbole für bedingte Kompilierung** das zu definierende Symbol ein. Wenn Sie z.B. das folgende Codebeispiel verwenden, geben Sie im Textfeld einfach `xx` ein.  
+2.  Geben Sie auf der Registerkarte **Build** im Feld **Symbole für bedingte Kompilierung** das zu definierende Symbol ein. Wenn Sie z.B. das folgende Codebeispiel verwenden, geben Sie im Textfeld einfach `xx` ein.  
   
  Informationen zum programmgesteuerten Festlegen dieser Compileroption finden Sie unter <xref:VSLangProj80.CSharpProjectConfigurationProperties3.DefineConstants%2A>.  
   

--- a/docs/csharp/language-reference/compiler-options/define-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/define-compiler-option.md
@@ -57,7 +57,7 @@ Die Option **-define** definiert `name` als Symbol in allen Quellcodedateien Ihr
   
 ### <a name="to-set-this-compiler-option-in-the-visual-studio-development-environment"></a>So legen Sie diese Compileroption in der Visual Studio-Entwicklungsumgebung fest  
   
-1.  Öffnen Sie die **Eigenschaftenseiten** des Projekts.  
+1.  Öffnen Sie die Seite **Eigenschaften** des Projekts.    
   
 2.  Geben Sie auf der Registerkarte **Build** im Feld **Symbole für bedingte Kompilierung** das zu definierende Symbol ein. Wenn Sie z.B. das folgende Codebeispiel verwenden, geben Sie im Textfeld einfach `xx` ein.  
   


### PR DESCRIPTION
**Build** tab is named **Build** in german version as well.
(VS Community 2017 v.15.6.1)